### PR TITLE
[WIP] FIX: Use top-level namespace for base classes

### DIFF
--- a/jobs/scheduled/check_policy.rb
+++ b/jobs/scheduled/check_policy.rb
@@ -2,7 +2,7 @@
 
 module Jobs
 
-  class ::DiscoursePolicy::CheckPolicy < Jobs::Scheduled
+  class ::DiscoursePolicy::CheckPolicy < ::Jobs::Scheduled
 
     every 6.hours
 


### PR DESCRIPTION
Zeitwerk is failing when we are searching for Jobs::Onceoff, Jobs::Base and Jobs::Scheduled without going back to the top-level namespace (this is correlated to the fact that we got Onceoff base class and module with the same name). 

I noticed that in plugins we are using sometimes :: and sometimes not and that gives me comfort that this change will not break anything.

Travis error: https://travis-ci.org/discourse/discourse/jobs/585072364