### PR TITLE
FEATURE: Ability to expire policy monthly, quarterly, yearly

### DIFF
--- a/app/models/post_policy.rb
+++ b/app/models/post_policy.rb
@@ -5,6 +5,8 @@ class PostPolicy < ActiveRecord::Base
   belongs_to :group
   has_many :policy_users
 
+  enum renew_interval: { monthly: 0, quarterly: 1, yearly: 2 }
+
   def accepted_by
     return [] if !policy_group
     policy_users

--- a/db/migrate/20200312233001_add_renew_interval_to_post_policies.rb
+++ b/db/migrate/20200312233001_add_renew_interval_to_post_policies.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddRenewIntervalToPostPolicies < ActiveRecord::Migration[6.0]
+  def up
+    add_column :post_policies, :renew_interval, :integer
+  end
+
+  def down
+    remove_column :post_policies, :renew_interval
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -121,8 +121,11 @@ after_initialize do
           end
         end
 
-        if (renew_days = policy["data-renew"].to_i) > 0
-          post_policy.renew_days = renew_days
+        renew_days = policy["data-renew"]
+        if (renew_days.to_i) > 0 || PostPolicy.renew_intervals.keys.include?(renew_days)
+          post_policy.renew_days = PostPolicy.renew_intervals.keys.include?(renew_days) ? nil : renew_days
+          post_policy.renew_interval = post_policy.renew_days.present? ? nil : renew_days
+
           post_policy.renew_start = nil
 
           if (renew_start = policy["data-renew-start"])


### PR DESCRIPTION
That feature was described here: https://meta.discourse.org/t/discourse-policy/88557/36

In general, we need an ability to expire policy monthly, quartely an yearly.

To achieve that, the policy is now accepting as `renew` param:
- integer - number of days
- monthly
- quarterly
- yearly