### PR TITLE
UX: When a policy reminder notification is sent mark it as high priority

### DIFF
--- a/jobs/scheduled/check_policy.rb
+++ b/jobs/scheduled/check_policy.rb
@@ -29,6 +29,7 @@ module Jobs
           post.post_policy.update(last_reminded_at: Time.zone.now)
 
           missing_users(post).each do |user|
+            clear_existing_notification(user, post)
             user.notifications.create!(
               notification_type: Notification.types[:topic_reminder],
               topic_id: post.topic_id,
@@ -88,6 +89,17 @@ module Jobs
 
     def missing_users(post)
       post.post_policy.not_accepted_by
+    end
+
+    def clear_existing_notification(user, post)
+      existing_notification = Notification.find_by(
+        notification_type: Notification.types[:topic_reminder],
+        topic_id: post.topic_id,
+        post_number: post.post_number,
+        user: user
+      )
+      return if existing_notification.blank?
+      existing_notification.delete
     end
   end
 end

--- a/jobs/scheduled/check_policy.rb
+++ b/jobs/scheduled/check_policy.rb
@@ -33,7 +33,8 @@ module Jobs
               notification_type: Notification.types[:topic_reminder],
               topic_id: post.topic_id,
               post_number: post.post_number,
-              data: { topic_title: post.topic.title, display_username: user.username }.to_json
+              data: { topic_title: post.topic.title, display_username: user.username }.to_json,
+              high_priority: true
             )
           end
         end

--- a/spec/lib/check_policy_spec.rb
+++ b/spec/lib/check_policy_spec.rb
@@ -228,7 +228,7 @@ describe DiscoursePolicy::CheckPolicy do
     end
   end
 
-  it "will correctly notify users" do
+  it "will correctly notify users with high priority notifications" do
     SiteSetting.queue_jobs = false
     freeze_time
 
@@ -250,7 +250,11 @@ describe DiscoursePolicy::CheckPolicy do
     DiscoursePolicy::CheckPolicy.new.execute
     DiscoursePolicy::CheckPolicy.new.execute
 
-    expect(user1.notifications.where(notification_type: Notification.types[:topic_reminder], topic_id: post.topic_id, post_number: 1).count).to eq(1)
-    expect(user2.notifications.where(notification_type: Notification.types[:topic_reminder], topic_id: post.topic_id, post_number: 1).count).to eq(1)
+    user1_notifications = user1.notifications.where(notification_type: Notification.types[:topic_reminder], topic_id: post.topic_id, post_number: 1)
+    expect(user1_notifications.count).to eq(1)
+    expect(user1_notifications.first.high_priority).to eq(true)
+    user2_notifications = user2.notifications.where(notification_type: Notification.types[:topic_reminder], topic_id: post.topic_id, post_number: 1)
+    expect(user2_notifications.count).to eq(1)
+    expect(user2_notifications.first.high_priority).to eq(true)
   end
 end


### PR DESCRIPTION
This is so policy reminders do not fall by the wayside. They are given the same priority as bookmark reminder and PM notifications, so they show with the green notification bubble.

Any existing reminder notification will be deleted as well, we don't want the user to end up with tons of duplicate notifications if the policy reminder is aggressive.

**NOTE: The PR https://github.com/discourse/discourse/pull/9660 MUST be merged first!**. I did not want to change _all_ topic reminder notifications to high priority.