### PR TITLE
DEV: Remove policy_max_group_size site setting

### DIFF
--- a/app/controllers/policy_controller.rb
+++ b/app/controllers/policy_controller.rb
@@ -72,10 +72,6 @@ class DiscoursePolicy::PolicyController < ::ApplicationController
       return render_json_error(I18n.t("discourse_policy.errors.user_missing"))
     end
 
-    if group.user_count > SiteSetting.policy_max_group_size
-      return render_json_error(I18n.t("discourse_policy.errors.too_large"))
-    end
-
     if SiteSetting.policy_restrict_to_staff_posts && !@post.user&.staff?
       return render_json_error(I18n.t("discourse_policy.errors.staff_only"))
     end

--- a/app/models/post_policy.rb
+++ b/app/models/post_policy.rb
@@ -43,7 +43,6 @@ class PostPolicy < ActiveRecord::Base
     return @policy_group if defined?(@policy_group)
 
     @policy_group = Group
-      .where('user_count < ?', SiteSetting.policy_max_group_size)
       .where('id in (SELECT group_id FROM post_policies WHERE post_id = ?)', post.id)
       .first
   end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1,12 +1,10 @@
 en:
   site_settings:
     policy_enabled: "Allow policies?"
-    policy_max_group_size: "Maximum number of users in a group that can have a policy applied"
     policy_restrict_to_staff_posts: "Policies may only appear on staff posts"
     policy_easy_revoke: "Show the accept and revoke buttons at the same time"
   discourse_policy:
     errors:
-      too_large: "Group is too large, it can not accept policies"
       user_missing: "User does not exist in group"
       group_not_found: "Group not found for policy"
       no_policy: "No policy exists for post"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -2,7 +2,6 @@ plugins:
   policy_enabled:
     default: true
     client: true
-  policy_max_group_size: 200
   policy_restrict_to_staff_posts:
     client: true
     default: true

--- a/spec/requests/policy_controller_spec.rb
+++ b/spec/requests/policy_controller_spec.rb
@@ -14,23 +14,6 @@ describe DiscoursePolicy::PolicyController do
     group.add(user2)
   end
 
-  it 'can not apply a policy to groups that are too big' do
-    SiteSetting.policy_max_group_size = 1
-
-    raw = <<~MD
-     [policy group=#{group.name}]
-     I always open **doors**!
-     [/policy]
-    MD
-
-    post = create_post(raw: raw, user: moderator)
-
-    sign_in(user1)
-    put "/policy/accept.json", params: { post_id: post.id }
-    expect(response.status).not_to eq(200)
-    expect(response.body).to include('too large')
-  end
-
   it 'can allows users to accept/reject policy' do
     raw = <<~MD
      [policy group=#{group.name}]


### PR DESCRIPTION
The plugin can handle very large groups with recent pages implementation.