### PR TITLE
UX: Show grey buttons for the other policy option

### DIFF
--- a/assets/javascripts/discourse/components/post-policy.js.es6
+++ b/assets/javascripts/discourse/components/post-policy.js.es6
@@ -63,7 +63,7 @@ export default Component.extend({
   @discourseComputed("post.policy_accepted", "post.policy_revoked")
   acceptButtonClasses(accepted, revoked) {
     let classes = "accept btn-accept-policy";
-    if (accepted || (!accepted && !revoked)) {
+    if (accepted || !revoked) {
       classes += " btn-primary";
     }
     return classes;
@@ -72,7 +72,7 @@ export default Component.extend({
   @discourseComputed("post.policy_accepted", "post.policy_revoked")
   revokeButtonClasses(accepted, revoked) {
     let classes = "accept btn-accept-policy";
-    if (revoked || (!accepted && !revoked)) {
+    if (revoked || !accepted) {
       classes += " btn-danger";
     }
     return classes;

--- a/assets/javascripts/discourse/components/post-policy.js.es6
+++ b/assets/javascripts/discourse/components/post-policy.js.es6
@@ -60,6 +60,24 @@ export default Component.extend({
     }
   },
 
+  @discourseComputed("post.policy_accepted", "post.policy_revoked")
+  acceptButtonClasses(accepted, revoked) {
+    let classes = "accept btn-accept-policy";
+    if (accepted || (!accepted && !revoked)) {
+      classes += " btn-primary";
+    }
+    return classes;
+  },
+
+  @discourseComputed("post.policy_accepted", "post.policy_revoked")
+  revokeButtonClasses(accepted, revoked) {
+    let classes = "accept btn-accept-policy";
+    if (revoked || (!accepted && !revoked)) {
+      classes += " btn-danger";
+    }
+    return classes;
+  },
+
   @discourseComputed(
     "post.policy_accepted_by_count",
     "post.policy_accepted_by.[]"

--- a/assets/javascripts/discourse/templates/components/post-policy.hbs
+++ b/assets/javascripts/discourse/templates/components/post-policy.hbs
@@ -4,7 +4,7 @@
       {{d-button
         isLoading=isLoading
         action=(action "acceptPolicy")
-        class="btn-primary accept btn-accept-policy"
+        class=acceptButtonClasses
         translatedLabel=options.acceptText
         icon=(if post.policy_accepted "check")
       }}
@@ -14,7 +14,7 @@
       {{d-button
         isLoading=isLoading
         action=(action "revokePolicy")
-        class="btn-danger revoke btn-revoke-policy"
+        class=revokeButtonClasses
         translatedLabel=options.revokeText
         icon=(if post.policy_revoked "check")
       }}


### PR DESCRIPTION
After accepting or revoking a policy, the other button will be grayed
out and only the selected option will have an icon and color.