### PR TITLE
FIX: Order displayed users and exclude inactive / suspended

### DIFF
--- a/app/controllers/policy_controller.rb
+++ b/app/controllers/policy_controller.rb
@@ -23,7 +23,6 @@ class DiscoursePolicy::PolicyController < ::ApplicationController
     users = @post
       .post_policy
       .accepted_by
-      .order(:id)
       .offset(params[:offset])
       .limit(DiscoursePolicy::POLICY_USER_DEFAULT_LIMIT)
 
@@ -37,7 +36,6 @@ class DiscoursePolicy::PolicyController < ::ApplicationController
     users = @post
       .post_policy
       .not_accepted_by
-      .order(:id)
       .offset(params[:offset])
       .limit(DiscoursePolicy::POLICY_USER_DEFAULT_LIMIT)
 

--- a/app/models/post_policy.rb
+++ b/app/models/post_policy.rb
@@ -10,13 +10,13 @@ class PostPolicy < ActiveRecord::Base
   def accepted_by
     return [] if !policy_group
 
-    User.where(id: accepted_policy_users.select(:user_id))
+    User.activated.not_suspended.where(id: accepted_policy_users.select(:user_id))
   end
 
   def revoked_by
     return [] if !policy_group
 
-    User.where(id: revoked_policy_users.select(:user_id))
+    User.activated.not_suspended.where(id: revoked_policy_users.select(:user_id))
   end
 
   def not_accepted_by
@@ -35,16 +35,18 @@ class PostPolicy < ActiveRecord::Base
     policy_users.revoked.with_version(version)
   end
 
-  def policy_group_users
-    User.joins(:group_users).where('group_users.group_id = ?', policy_group.id)
-  end
-
   def policy_group
     return @policy_group if defined?(@policy_group)
 
     @policy_group = Group
       .where('id in (SELECT group_id FROM post_policies WHERE post_id = ?)', post.id)
       .first
+  end
+
+  private
+
+  def policy_group_users
+    User.activated.joins(:group_users).where('group_users.group_id = ?', policy_group.id)
   end
 end
 

--- a/app/models/post_policy.rb
+++ b/app/models/post_policy.rb
@@ -10,13 +10,13 @@ class PostPolicy < ActiveRecord::Base
   def accepted_by
     return [] if !policy_group
 
-    User.activated.not_suspended.where(id: accepted_policy_users.select(:user_id))
+    User.activated.not_suspended.where(id: accepted_policy_users.select(:user_id)).order(:id)
   end
 
   def revoked_by
     return [] if !policy_group
 
-    User.activated.not_suspended.where(id: revoked_policy_users.select(:user_id))
+    User.activated.not_suspended.where(id: revoked_policy_users.select(:user_id)).order(:id)
   end
 
   def not_accepted_by
@@ -46,7 +46,7 @@ class PostPolicy < ActiveRecord::Base
   private
 
   def policy_group_users
-    User.activated.joins(:group_users).where('group_users.group_id = ?', policy_group.id)
+    User.activated.not_suspended.joins(:group_users).where('group_users.group_id = ?', policy_group.id).order(:id)
   end
 end
 

--- a/spec/fabricators/post_policy_fabricator.rb
+++ b/spec/fabricators/post_policy_fabricator.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+Fabricator(:post_policy) do
+  group
+  post
+end

--- a/spec/models/post_policy_spec.rb
+++ b/spec/models/post_policy_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 describe PostPolicy do
   before do
-    SiteSetting.queue_jobs = false
+    Jobs.run_immediately!
   end
 
   fab!(:user1) { Fabricate(:user, id: 123456789) }


### PR DESCRIPTION
Two problems:

1. We were returning suspended users, which we don't really care about when displaying.

2. When returning the first set of 25 users per policy, they were not ordered by ID. The controller that paginates (by an offset of 25) orders users by ID, causing duplicates depending on how the first set was returned.