### PR TITLE
FIX: Clear next_renew_at when renew-start is removed.

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -77,7 +77,10 @@ after_initialize do
             rescue ArgumentError
               # already nil
             end
+          else
+            post_policy.next_renew_at = nil
           end
+
         else
           post_policy.renew_days = nil
           post_policy.renew_start = nil

--- a/spec/lib/check_policy_spec.rb
+++ b/spec/lib/check_policy_spec.rb
@@ -288,4 +288,12 @@ describe DiscoursePolicy::CheckPolicy do
     expect(user1.notifications.where(notification_type: Notification.types[:topic_reminder], topic_id: post.topic_id, post_number: 1).count).to eq(1)
     expect(Notification.find_by(id: user1_notification.id)).to eq(nil)
   end
+
+  it "clears the next_renew_at when renew_start is nil" do
+    policy = Fabricate(:post_policy, next_renew_at: 3.hours.ago, renew_start: nil, renew_days: 10)
+
+    DiscoursePolicy::CheckPolicy.new.execute
+
+    expect(policy.reload.next_renew_at).to be_nil
+  end
 end

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'plugin' do
+  describe 'post_process_cooked event' do
+    before { Jobs.run_immediately! }
+
+    it 'sets next_renew_at when removing renew-start but not renew' do
+      group = Fabricate(:group)
+      renew_days = 10
+      renew_start = 1.day.from_now.to_date
+      raw = <<~MD
+       [policy group=#{group.name} renew="#{renew_days}" renew-start="#{renew_start.strftime('%F')}"]
+        Here's the new policy
+       [/policy]
+      MD
+
+      post = create_post(raw: raw, user: Fabricate(:admin))
+      policy = PostPolicy.find_by(post: post)
+
+      expect(policy.renew_days).to eq(renew_days)
+      expect(policy.renew_start).to eq(renew_start)
+      expect(policy.next_renew_at.to_date).to eq(renew_start)
+
+      updated_policy = <<~MD
+       [policy group=#{group.name} renew="#{renew_days}"]
+        Here's the new policy
+       [/policy]
+      MD
+
+      post.update!(raw: updated_policy)
+      post.rebake!
+      policy = policy.reload
+
+      expect(policy.renew_days).to eq(renew_days)
+      expect(policy.renew_start).to be_nil
+      expect(policy.next_renew_at).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
If we create a poll using the renew and renew-start options but later remove the latter, the event doesn't clear the `next_renew_at` attribute. Due to this, the `CheckPolicy` will try to compare renew_start with the current time,
but this value will be nil.