### PR TITLE
FIX: ensures builder state is correctly set

### DIFF
--- a/assets/javascripts/initializers/add-policy-builder.js.es6
+++ b/assets/javascripts/initializers/add-policy-builder.js.es6
@@ -26,6 +26,8 @@ function initializePolicyBuilder(api, container) {
     actions: {
       insertPolicy() {
         showModal("policy-builder").setProperties({
+          insertMode: true,
+          post: null,
           toolbarEvent: this.toolbarEvent,
         });
       },


### PR DESCRIPTION
Prior to this change editing an existing policy and then creating a new policy would start the builder in editing mode and not insert mode.