### PR TITLE
FIX: Use activerecord's `none` method instead of returning empty array.

### DIFF
--- a/app/models/post_policy.rb
+++ b/app/models/post_policy.rb
@@ -14,19 +14,19 @@ class PostPolicy < ActiveRecord::Base
   enum renew_interval: { monthly: 0, quarterly: 1, yearly: 2 }
 
   def accepted_by
-    return [] if !groups.exists?
+    return User.none if !groups.exists?
 
     User.activated.not_suspended.where(id: accepted_policy_users.select(:user_id)).order(:id)
   end
 
   def revoked_by
-    return [] if !groups.exists?
+    return User.none if !groups.exists?
 
     User.activated.not_suspended.where(id: revoked_policy_users.select(:user_id)).order(:id)
   end
 
   def not_accepted_by
-    return [] if !groups.exists?
+    return User.none if !groups.exists?
 
     policy_group_users.where.not(id: accepted_policy_users.select(:user_id))
   end

--- a/spec/serializers/post_serializer_spec.rb
+++ b/spec/serializers/post_serializer_spec.rb
@@ -46,6 +46,25 @@ describe 'post serializer' do
     expect(accepted.map { |u| u[:id] }).to contain_exactly(user1.id)
   end
 
+  it 'works if group not found' do
+    raw = <<~MD
+     [policy group=#{group.name}]
+     I always open **doors**!
+     [/policy]
+    MD
+
+    post = create_post(raw: raw, user: Fabricate(:admin))
+    post.reload
+
+    group.destroy!
+
+    json = PostSerializer.new(post, scope: Guardian.new).as_json
+
+    not_accepted = json[:post][:policy_not_accepted_by]
+
+    expect(not_accepted.length).to eq(0)
+  end
+
   it 'excludes inactive users' do
     user1.active = false
     user1.save!


### PR DESCRIPTION
We can't use `exists?` method [here](https://github.com/discourse/discourse-policy/blame/8bbd564db11f554565845a2d4d19d8cbb2b7e0be/plugin.rb#L187) if we return an empty array (`[]`). So we're going to use `User.none` method instead.