### PR TITLE
DEV: Correct the `PLUGIN_NAME`

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -17,7 +17,7 @@ enabled_site_setting :policy_enabled
 
 after_initialize do
   module ::DiscoursePolicy
-    PLUGIN_NAME = "discourse_policy"
+    PLUGIN_NAME = "discourse-policy"
     HAS_POLICY = "HasPolicy"
     POLICY_USER_DEFAULT_LIMIT = 25
 


### PR DESCRIPTION
Fixes `Required plugin 'discourse_policy' not found` warnings