### PR TITLE
DEV: Replace deprecated queue_jobs site setting in tests

### DIFF
--- a/spec/lib/check_policy_spec.rb
+++ b/spec/lib/check_policy_spec.rb
@@ -219,7 +219,7 @@ describe DiscoursePolicy::CheckPolicy do
   end
 
   it "will correctly notify users with high priority notifications" do
-    SiteSetting.queue_jobs = false
+    Jobs.run_immediately!
     freeze_time
 
     raw = <<~MD
@@ -263,7 +263,7 @@ describe DiscoursePolicy::CheckPolicy do
   end
 
   it "will delete the existing policy reminder notification before creating a new one" do
-    SiteSetting.queue_jobs = false
+    Jobs.run_immediately!
     freeze_time
 
     raw = <<~MD

--- a/spec/lib/pretty_text_spec.rb
+++ b/spec/lib/pretty_text_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 describe PrettyText do
-  before { SiteSetting.queue_jobs = false }
+  before { Jobs.run_immediately! }
 
   it "can properly decorate policies (legacy)" do
     raw = <<~MD

--- a/spec/models/policy_user_spec.rb
+++ b/spec/models/policy_user_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 describe PolicyUser do
-  before { SiteSetting.queue_jobs = false }
+  before { Jobs.run_immediately! }
 
   fab!(:user) { Fabricate(:user) }
 


### PR DESCRIPTION
### What is this change?

The `#queue_jobs=` method on site settings has been [deprecated](https://github.com/discourse/discourse/commit/1b65469b64e9e569fed67ae11f1dd9ee37702f5c) and replaced by `Jobs.run_later!` and `Jobs.run_immediately!`. This PR replaces usages in this plugin so we can remove the fallback in core.

The fallback used in core for reference:

https://github.com/discourse/discourse/blob/main/app/models/site_setting.rb#L109-L115