### PR TITLE
FEATURE: Track when a policy version is bumped

### DIFF
--- a/app/models/post_policy.rb
+++ b/app/models/post_policy.rb
@@ -6,11 +6,14 @@ class PostPolicy < ActiveRecord::Base
   ]
 
   belongs_to :post
+
   has_many :post_policy_groups, dependent: :destroy
   has_many :groups, through: :post_policy_groups
   has_many :policy_users
 
   enum renew_interval: { monthly: 0, quarterly: 1, yearly: 2 }
+
+  before_save :bump_policy
 
   def accepted_by
     return User.none if !groups.exists?
@@ -49,6 +52,10 @@ class PostPolicy < ActiveRecord::Base
   end
 
   private
+
+  def bump_policy
+    self.last_bumped_at = Time.current if version_changed?
+  end
 
   def emails_enabled_users
     policy_group_users.joins(:user_option).where(

--- a/db/migrate/20231204161807_add_last_bumped_at_to_post_policies.rb
+++ b/db/migrate/20231204161807_add_last_bumped_at_to_post_policies.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddLastBumpedAtToPostPolicies < ActiveRecord::Migration[7.0]
+  def change
+    add_column :post_policies, :last_bumped_at, :datetime
+  end
+end


### PR DESCRIPTION
Currently we have queries to check who hasn’t accepted a policy and when that policy was last triggered for that person.
The problem is that it’s not always reliable as we don’t have a way of knowing when the policy version was bumped for the last time.

This PR adds a new `last_bumped_at` field which will be updated automatically each time the version changes. That way we’ll be able to have more reliable queries.