### PR TITLE
FIX: BBCode parsing specs

### DIFF
--- a/assets/javascripts/lib/discourse-markdown/policy.js
+++ b/assets/javascripts/lib/discourse-markdown/policy.js
@@ -6,18 +6,14 @@ const rule = {
       return false;
     }
 
-    token.attrs = [
-      ["class", "policy"],
-      info.attrs.group && ["data-group", info.attrs.group],
-      info.attrs.groups && ["data-groups", info.attrs.groups],
-      ["data-version", info.attrs.version || 1],
-      info.attrs.renew && ["data-renew", info.attrs.renew],
-      info.attrs.reminder && ["data-reminder", info.attrs.reminder],
-      info.attrs.accept && ["data-accept", info.attrs.accept],
-      info.attrs.revoke && ["data-revoke", info.attrs.revoke],
-      info.attrs.start && ["data-renew-start", info.attrs.start],
-      info.attrs.private && ["data-private", info.attrs.private],
-    ].filter(Boolean);
+    token.attrs = [["class", "policy"]];
+
+    // defaults to version 1 of the policy
+    info.attrs.version ||= 1;
+
+    for (let key of Object.keys(info.attrs).sort()) {
+      token.attrs.push([`data-${key}`, info.attrs[key]]);
+    }
 
     return true;
   },

--- a/spec/lib/pretty_text_spec.rb
+++ b/spec/lib/pretty_text_spec.rb
@@ -7,13 +7,13 @@ describe PrettyText do
 
   it "can properly decorate policies (legacy)" do
     raw = <<~MD
-     [policy group=team renew-start="01-01-2010" reminder=weekly accept=banana revoke=apple]
-     I always open **doors**!
-     [/policy]
+      [policy group=team renew-start="2010-01-01" reminder=weekly accept=banana revoke=apple]
+      I always open **doors**!
+      [/policy]
     MD
 
     cooked = (<<~HTML).strip
-      <div class="policy" data-group="team" data-version="1" data-reminder="weekly" data-accept="banana" data-revoke="apple" data-renew-start="01-01-2010">
+      <div class="policy" data-accept="banana" data-group="team" data-reminder="weekly" data-renew-start="2010-01-01" data-revoke="apple" data-version="1">
       <p>I always open <strong>doors</strong>!</p>
       </div>
     HTML
@@ -23,13 +23,13 @@ describe PrettyText do
 
   it "can properly decorate policies" do
     raw = <<~MD
-     [policy groups=team,staff renew-start="01-01-2010" reminder=weekly accept=banana revoke=apple]
-     I always open **doors**!
-     [/policy]
+      [policy groups=team,staff renew-start="2010-01-01" reminder=weekly accept=banana revoke=apple]
+      I always open **doors**!
+      [/policy]
     MD
 
     cooked = (<<~HTML).strip
-      <div class="policy" data-groups="team,staff" data-version="1" data-reminder="weekly" data-accept="banana" data-revoke="apple" data-renew-start="01-01-2010">
+      <div class="policy" data-accept="banana" data-groups="team,staff" data-reminder="weekly" data-renew-start="2010-01-01" data-revoke="apple" data-version="1">
       <p>I always open <strong>doors</strong>!</p>
       </div>
     HTML
@@ -41,9 +41,9 @@ describe PrettyText do
     SiteSetting.policy_restrict_to_staff_posts = false
 
     raw = <<~MD
-     [policy group=staff reminder=weekly]
-     I always open **doors**!
-     [/policy]
+      [policy group=staff reminder=weekly]
+      I always open **doors**!
+      [/policy]
     MD
 
     post = create_post(raw: raw)
@@ -66,9 +66,9 @@ describe PrettyText do
     user = Fabricate(:admin)
 
     raw = <<~MD
-     [policy group=staff renew=200]
-     I always open **doors**!
-     [/policy]
+      [policy group=staff renew=200]
+      I always open **doors**!
+      [/policy]
     MD
 
     post = create_post(raw: raw)
@@ -80,7 +80,7 @@ describe PrettyText do
 
     freeze_time(2.days.from_now)
     ::DiscoursePolicy::CheckPolicy.new.execute(nil)
-    expect(post.post_policy.accepted_by).to eq([])
+    expect(post.post_policy.accepted_by).to be_empty
   end
 
   it "resets list of accepted users if version is bumped" do
@@ -91,9 +91,9 @@ describe PrettyText do
     user = Fabricate(:admin)
 
     raw = <<~MD
-     [policy group=staff reminder=weekly]
-     I always open **doors**!
-     [/policy]
+      [policy group=staff reminder=weekly]
+      I always open **doors**!
+      [/policy]
     MD
 
     post = create_post(raw: raw)
@@ -102,23 +102,24 @@ describe PrettyText do
 
     post = Post.find(post.id)
 
-    expect(post.post_policy.accepted_by).to eq([user])
-
+    expect(post.post_policy.accepted_by).to contain_exactly(user)
     expect(post.post_policy.reminder).to eq("weekly")
     expect(post.post_policy.last_reminded_at).to eq_time(Time.zone.now)
-    expect(post.post_policy.groups.pluck(:name).sort).to eq(["staff"])
+    expect(post.post_policy.groups.pluck(:name)).to contain_exactly("staff")
 
     raw = <<~MD
-     [policy groups=trust_level_1,trust_level_0 version=2 reminder=weekly]
-     I always open **doors**!
-     [/policy]
+      [policy groups=trust_level_1,trust_level_0 version=2 reminder=weekly]
+      I always open **doors**!
+      [/policy]
     MD
 
     post.revise(post.user, raw: raw)
 
     post = Post.find(post.id)
-    expect(post.post_policy.accepted_by).to eq([])
-
-    expect(post.post_policy.groups.pluck(:name).sort).to eq(%w[trust_level_0 trust_level_1])
+    expect(post.post_policy.accepted_by).to be_empty
+    expect(post.post_policy.groups.pluck(:name)).to contain_exactly(
+      "trust_level_0",
+      "trust_level_1",
+    )
   end
 end


### PR DESCRIPTION
Requires https://github.com/discourse/discourse/pull/27173 to be merged.

Will add a `.discourse-compatibility` once merged.