### PR TITLE
PERF: Use `find_each` to avoid memory spikes

### DIFF
--- a/jobs/scheduled/check_policy.rb
+++ b/jobs/scheduled/check_policy.rb
@@ -28,7 +28,7 @@ module Jobs
           .find_each do |post|
             post.post_policy.update(last_reminded_at: Time.zone.now)
 
-            missing_users(post).each do |user|
+            missing_users(post).find_each do |user|
               clear_existing_notification(user, post)
               user.notifications.create!(
                 notification_type: Notification.types[:topic_reminder],


### PR DESCRIPTION
This commit updates the method call on `::DiscoursePolicy::CheckPolicy#missing_users`
to use `find_each` instead of `each`. This avoids loading all the `User`
ActiveRecord models into memory at once when a policy has many missing
users.
