### PR TITLE
PERF: Use `find_each` to avoid memory spikes take 2

### DIFF
--- a/jobs/scheduled/check_policy.rb
+++ b/jobs/scheduled/check_policy.rb
@@ -39,7 +39,7 @@ module Jobs
               )
             end
 
-            users_to_email(post).each do |user|
+            users_to_email(post).find_each do |user|
               DiscoursePolicy::PolicyMailer.send_email(user, post)
             end
           end


### PR DESCRIPTION
This is a follow up to 9c82f0b08f70824937f642a9c98946f64fae4602 which
applies the same optimisation.
