### PR TITLE
DEV: resolve Rails/ReversibleMigrationMethodDefinition errors

### DIFF
--- a/db/migrate/20190817010201_migrate_post_policy_data.rb
+++ b/db/migrate/20190817010201_migrate_post_policy_data.rb
@@ -58,4 +58,8 @@ class MigratePostPolicyData < ActiveRecord::Migration[5.2]
       )
     SQL
   end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
 end

--- a/db/migrate/20191014224419_migrate_custom_field_to_policy_users.rb
+++ b/db/migrate/20191014224419_migrate_custom_field_to_policy_users.rb
@@ -14,4 +14,8 @@ class MigrateCustomFieldToPolicyUsers < ActiveRecord::Migration[5.2]
     DELETE FROM post_custom_fields WHERE name = 'PolicyAcceptedBy'
     SQL
   end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
 end


### PR DESCRIPTION
We are adding the Rails/ReversibleMigrationMethodDefinition cop to rubocop-discourse, this change resolves existing errors under this rule.