### PR TITLE
DEV: Update more deprecated Font Awesome icon names

### DIFF
--- a/assets/javascripts/discourse/components/post-policy.gjs
+++ b/assets/javascripts/discourse/components/post-policy.gjs
@@ -364,7 +364,7 @@ export default class PostPolicy extends Component {
         {{#if this.canManagePolicy}}
           <DButton
             @action={{this.editPolicy}}
-            @icon="cog"
+            @icon="gear"
             class="no-text btn-default edit-policy-settings-btn"
           />
         {{/if}}


### PR DESCRIPTION
This PR updates more deprecated Font Awesome icon names. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.