### PR TITLE
FIX: Resolve policy footer layout issues on mobile

### DIFF
--- a/assets/stylesheets/common/discourse-policy.scss
+++ b/assets/stylesheets/common/discourse-policy.scss
@@ -13,9 +13,10 @@
     align-items: center;
     display: flex;
     justify-content: space-between;
+    gap: 1rem;
 
-    .btn {
-      white-space: nowrap;
+    @include breakpoint("tablet") {
+      flex-direction: column;
     }
   }
 
@@ -48,12 +49,11 @@
   }
 
   .user-lists {
-    padding-left: 0.75em;
     display: flex;
     font-size: var(--font-up-1);
+    gap: 0.5rem;
 
     .users {
-      margin-left: 0.5em;
       display: flex;
       align-items: center;
       flex-wrap: wrap;
@@ -66,8 +66,6 @@
 
   .separator {
     border-right: 2px solid var(--primary-low);
-    margin: 0 0.5em;
-    padding: 0.75em 0em;
   }
 
   .see-policy-settings-btn,
@@ -94,9 +92,22 @@
 .cooked .policy {
   .policy-actions {
     display: flex;
+    gap: 0.5rem;
+    max-width: 50%;
+    flex-wrap: wrap;
+
+    @include breakpoint("medium") {
+      width: 100%;
+      max-width: 100%;
+    }
 
     .btn {
-      margin-right: 0.25em;
+      white-space: nowrap;
+
+      @include breakpoint("large") {
+        width: 100%;
+        white-space: inherit;
+      }
     }
   }
 


### PR DESCRIPTION

### Before
<img width="286" alt="image" src="https://github.com/user-attachments/assets/9dc08ffc-6235-4870-ace4-c4039e849d2d">
<img width="286" alt="image" src="https://github.com/user-attachments/assets/82877818-dd5d-46af-84e9-7573bcccf6ee">



### After
<img width="290" alt="image" src="https://github.com/user-attachments/assets/f36d4a49-58fc-4fd3-8dfd-d3bcf3977f5c">

<img width="296" alt="image" src="https://github.com/user-attachments/assets/5f6003f6-1154-41fb-a3f5-ce12edc21452">

