### PR TITLE
FIX: hide "no possible users" when regular user

### DIFF
--- a/assets/javascripts/discourse/components/post-policy.gjs
+++ b/assets/javascripts/discourse/components/post-policy.gjs
@@ -3,6 +3,7 @@ import { tracked } from "@glimmer/tracking";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
+import { and, not } from "truth-helpers";
 import DButton from "discourse/components/d-button";
 import avatar from "discourse/helpers/bound-avatar-template";
 import icon from "discourse/helpers/d-icon";
@@ -282,11 +283,11 @@ export default class PostPolicy extends Component {
         </div>
 
         <div class="user-lists">
-          {{#unless this.policyHasUsers}}
+          {{#if (and (not this.policyHasUsers) this.post.policy_stats)}}
             <span class="no-possible-users">
               {{i18n "discourse_policy.no_possible_users"}}
             </span>
-          {{/unless}}
+          {{/if}}
 
           {{#if this.post.policy_accepted_by_count}}
             <a

--- a/lib/extensions/post_serializer_extension.rb
+++ b/lib/extensions/post_serializer_extension.rb
@@ -12,7 +12,8 @@ module DiscoursePolicy
                  :policy_not_accepted_by,
                  :policy_not_accepted_by_count,
                  :policy_accepted_by,
-                 :policy_accepted_by_count
+                 :policy_accepted_by_count,
+                 :policy_stats
 
       delegate :post_policy, to: :object
 
@@ -31,6 +32,10 @@ module DiscoursePolicy
 
     def include_policy?
       SiteSetting.policy_enabled? && post_custom_fields[DiscoursePolicy::HAS_POLICY]
+    end
+
+    def policy_stats
+      true
     end
 
     def include_policy_stats?

--- a/spec/serializers/post_serializer_spec.rb
+++ b/spec/serializers/post_serializer_spec.rb
@@ -119,6 +119,7 @@ describe PostSerializer do
     json = PostSerializer.new(post, scope: Guardian.new).as_json
     expect(json[:post][:policy_not_accepted_by]).to eq(nil)
     expect(json[:post][:policy_accepted_by]).to eq(nil)
+    expect(json[:post][:policy_stats]).to eq(nil)
 
     json = PostSerializer.new(post, scope: admin.guardian).as_json
     expect(json[:post][:policy_not_accepted_by].map { |u| u[:id] }).to contain_exactly(

--- a/test/javascripts/integration/components/post-policy-test.gjs
+++ b/test/javascripts/integration/components/post-policy-test.gjs
@@ -101,6 +101,7 @@ module(
         fabricatePost({
           policy_accepted_by_count: 0,
           policy_not_accepted_by_count: 0,
+          policy_stats: true,
         })
       );
       this.set("policy", fabricatePolicy());
@@ -114,6 +115,27 @@ module(
       assert
         .dom(".no-possible-users")
         .hasText(i18n("discourse_policy.no_possible_users"));
+    });
+
+    test("does not show 'no possible users' when no access to stats", async function (assert) {
+      const self = this;
+
+      this.set(
+        "post",
+        fabricatePost({
+          policy_accepted_by_count: 0,
+          policy_not_accepted_by_count: 0,
+        })
+      );
+      this.set("policy", fabricatePolicy());
+
+      await render(
+        <template>
+          <PostPolicy @post={{self.post}} @policy={{self.policy}} />
+        </template>
+      );
+
+      assert.dom(".no-possible-users").doesNotExist();
     });
 
     test("toggle state", async function (assert) {


### PR DESCRIPTION
When policy is private, we should only display "no possible users" text for admins.

**Regular user view of public and private policy**
<img width="785" alt="Screenshot 2025-06-20 at 3 37 01 pm" src="https://github.com/user-attachments/assets/713aed9b-2581-413e-bf89-4f757dd614a5" />
<img width="794" alt="Screenshot 2025-06-20 at 3 36 35 pm" src="https://github.com/user-attachments/assets/c2e39424-38ac-4481-8db2-f3bbd3500b69" />
**Admin view of private policy**
<img width="783" alt="Screenshot 2025-06-20 at 3 37 08 pm" src="https://github.com/user-attachments/assets/bb4149bc-f230-4e6f-a4f2-33fc3d6b9e80" />


